### PR TITLE
Compute fitness based on returns instead of total wealth

### DIFF
--- a/libcapgen/src/genetic.cpp
+++ b/libcapgen/src/genetic.cpp
@@ -308,7 +308,7 @@ double compute_fitness(
       n_derivatives,
       n_scenarios);
 
-  return ((1.0 - risk_aversion) * wealth) - (risk_aversion * risk) - penalty;
+  return std::max(0.0, ((1.0 - risk_aversion) * (wealth - 1.0)) - (risk_aversion * risk));
 }
 
 double compute_penalty(
@@ -516,7 +516,7 @@ Result optimize(OptimizeOptions options)
   const int n_genes = n_scenarios * n_instruments;
 
   // Will contain the final result
-  double best_fitness = std::numeric_limits<double>::min();
+  double best_fitness = 0.0;
   std::vector<double> best_individual = std::vector<double>(n_genes, 0.0);
 
   // Generate initial individuals
@@ -572,7 +572,7 @@ Result optimize(OptimizeOptions options)
     // Check global best fitness
     for (int i = 0; i < n_individuals; ++i)
     {
-      if (fitnesses[i] > best_fitness)
+      if (fitnesses[i] >= best_fitness)
       {
         const int ix = i * n_genes;
         best_fitness = fitnesses[i];

--- a/libcapgen/test/genetic.test.cpp
+++ b/libcapgen/test/genetic.test.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <lib/catch.h>
 #include <lib/random.h>
 
@@ -297,7 +296,7 @@ TEST_CASE("compute_fitnesses correctly computes the fitness of all individuals",
   std::vector<double> fitnesses = compute_fitnesses(individuals, instrument_changes, transaction_costs, goals, instrument_constraints, margin_constraints, risk_aversion, n_individuals, n_instruments, n_derivatives, n_scenarios);
 
   std::vector<double> expected_fitnesses = {
-      1.0, 1.5, 1.3125};
+      0.0, 0.5, 0.3125};
 
   for (int i = 0; i < expected_fitnesses.size(); ++i)
   {
@@ -362,13 +361,13 @@ TEST_CASE("optimization runs without crashing", "[genetic]")
   MarginConstraints margin_constraints = create_default_margin_constraints();
 
   OptimizeOptions options;
-  options.population_size = 1;
-  options.elitism_copies = 0;
-  options.generations = 1;
-  options.steps = 2;
+  options.population_size = 10;
+  options.elitism_copies = 1;
+  options.generations = 10;
+  options.steps = 3;
   options.mutation_rate = 0.02;
-  options.crossover_rate = 0.01;
-  options.risk_aversion = 0.0;
+  options.crossover_rate = 0.02;
+  options.risk_aversion = 0.5;
   options.initial_funding_ratio = 1.0;
   options.target_funding_ratio = 1.0;
   options.transaction_costs = transaction_costs;

--- a/libcapgen/test/normal.test.cpp
+++ b/libcapgen/test/normal.test.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <lib/catch.h>
 #include <lib/random.h>
 
@@ -77,10 +76,6 @@ TEST_CASE("generate_normal_scenarios yields reasonable changes", "[normal]")
       n_risks,
       n_instruments,
       n_scenarios);
-
-  for (auto c : instrument_changes)
-    std::cout << c << " ";
-  std::cout << "\n";
 
   for (int i = 0; i < instrument_changes.size(); ++i)
   {

--- a/scripts/normals.m
+++ b/scripts/normals.m
@@ -1,21 +1,28 @@
 clear;
 
 max_rows = 2530;
+span = 30;
 
 domesticEquityData = readmatrix('../data/omxs301d.csv');
 domesticEquityChanges = domesticEquityData(:, 3);
+domesticEquityChanges = domesticEquityChanges(1:span:max_rows, :);
 domesticEquityModel = fitdist(domesticEquityChanges, 'Normal');
 
 globalEquityData = readmatrix('../data/msciworld1d-filtered.csv');
 globalEquityChanges = globalEquityData(:, 3);
+globalEquityChanges = globalEquityChanges(1:span:max_rows, :);
 globalEquityModel = fitdist(globalEquityChanges, 'Normal');
 
 alternativeChanges = zeros(max_rows, 1);
+alternativeChanges = alternativeChanges(1:span:max_rows, :);
+
 creditChanges = zeros(max_rows, 1);
+creditChanges = creditChanges(1:span:max_rows, :);
 
 usdSekData = readmatrix('../data/usdsek1d.csv');
 usdSekValues = usdSekData(:, 2);
 usdSekChanges = diff(usdSekValues)./usdSekValues(1:size(usdSekValues)-1); 
+usdSekChanges = usdSekChanges(1:span:max_rows, :);
 usdSekModel = fitdist(usdSekChanges, 'Normal');
 
 swapData = readmatrix('../data/swap1d-filtered.csv');
@@ -23,29 +30,35 @@ swapData = readmatrix('../data/swap1d-filtered.csv');
 swap2YValues = swapData(:, 3);
 swap2YChanges = diff(swap2YValues)./swap2YValues(1:size(swap2YValues)-1); 
 swap2YChanges = swap2YChanges(~any(isinf(swap2YChanges), 2), :);
+swap2YChanges = swap2YChanges(1:span:max_rows, :);
 swap2YModel = fitdist(swap2YChanges, 'Normal');
 
 swap5YValues = swapData(:, 6);
 swap5YChanges = diff(swap5YValues)./swap5YValues(1:size(swap5YValues)-1); 
+swap5YChanges = swap5YChanges(1:span:max_rows, :);
 swap5YModel = fitdist(swap5YChanges, 'Normal');
 
 swap20YValues = swapData(:, 14);
 swap20YChanges = diff(swap20YValues)./swap20YValues(1:size(swap20YValues)-1); 
+swap20YChanges = swap20YChanges(1:span:max_rows, :);
 swap20YModel = fitdist(swap20YChanges, 'Normal');
 
+domesticEquityModel
+globalEquityModel
+usdSekMode
 swap2YModel
 swap5YModel
 swap20YModel
 
 C = corrcoef([
-  domesticEquityChanges(1:max_rows, 1)';
-  globalEquityChanges(1:max_rows, 1)';
-  alternativeChanges(1:max_rows, 1)';
-  swap2YChanges(1:max_rows, 1)';
-  swap5YChanges(1:max_rows, 1)';
-  swap20YChanges(1:max_rows, 1)';
-  creditChanges(1:max_rows, 1)';
-  usdSekChanges(1:max_rows, 1)'
+  domesticEquityChanges';
+  globalEquityChanges';
+  alternativeChanges';
+  swap2YChanges';
+  swap5YChanges';
+  swap20YChanges';
+  creditChanges';
+  usdSekChanges'
 ]');
 
 

--- a/src/Simulator/Simulator.js
+++ b/src/Simulator/Simulator.js
@@ -17,7 +17,7 @@ export const Simulator = withTheme(({ theme, ...rest }) => (
           generations: 10,
           mutationRate: 0.02,
           crossoverRate: 0.02,
-          steps: 4,
+          steps: 2,
           riskAversion: 0.0,
           initialFundingRatio: 1.3,
           targetFundingRatio: 1.3,


### PR DESCRIPTION
- Use returns instead of total wealth when computing fitness
- Fixed a bug where the algorithm reported individuals with weights `[0, 0, 0, 0, ...]` when it did not converge.